### PR TITLE
Allow overriding path to uglify-js node module with -D uglifyjs_bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ To use in code, add to your build hxml:
 # keep JavaScript comments
 -D uglifyjs_comments
 -D uglifyjs_comments=filter
+
+# override default uglify-js node module path
+-D uglifyjs_bin=path/to/bin/uglifyjs
 ```

--- a/src/UglifyJS.hx
+++ b/src/UglifyJS.hx
@@ -47,9 +47,11 @@ class UglifyJS {
 	}
 
 	static function getCmd() {
-		var cmd = Sys.systemName() == 'Windows'
-			? 'node_modules\\.bin\\uglifyjs.cmd'
-			: './node_modules/.bin/uglifyjs';
+		var cmd = Context.defined('uglifyjs_bin')
+			? Context.definedValue('uglifyjs_bin')
+			: Sys.systemName() == 'Windows'
+				? 'node_modules\\.bin\\uglifyjs.cmd'
+				: './node_modules/.bin/uglifyjs';
 		if (!FileSystem.exists(cmd)) cmd = 'uglifyjs'; // try global
 		return cmd;
 	}

--- a/src/UglifyJS.hx
+++ b/src/UglifyJS.hx
@@ -32,15 +32,17 @@ class UglifyJS {
 			'--mangle',
 			#end
 			#if uglifyjs_comments
-			'--comments', 
+			'--comments',
 			#end
 			'--output', outPath,
 			'--', inPath
 		];
-		
+
+		#if uglifyjs_comments
 		var uglifyjs_comments = Context.definedValue("uglifyjs_comments");
 		if (uglifyjs_comments.length > 1) params.insert(params.indexOf("--comments") + 1, uglifyjs_comments);
-		
+		#end
+
 		Sys.command(getCmd(), params);
 	}
 


### PR DESCRIPTION
Also fixes an `Invalid field access` error when `-D uglifyjs_comments` isn't defined.